### PR TITLE
Install from GitHub

### DIFF
--- a/_pages/downloads.md
+++ b/_pages/downloads.md
@@ -7,15 +7,19 @@ permalink: /downloads/
 
 ## Silver
 
+* [Silver GitHub repository](https://github.com/melt-umn/silver)
 * [Silver 0.4](/downloads/silver-0.4.0.tar.gz)
 
 ## Copper
 
+* [Copper GitHub repository](https://github.com/melt-umn/copper)
 * [CopperCompiler-0.5](/downloads/CopperCompiler-0.5.jar)
 * [CopperRuntime-0.5](/downloads/CopperRuntime-0.5.jar)
 * [copper-examples](/downloads/copper_examples.tar.gz)
 
 ## ableC
+
+* [ableC GitHub repository](https://github.com/melt-umn/ableC)
 
 Version 0.1
 

--- a/silver/install-guide/index.md
+++ b/silver/install-guide/index.md
@@ -10,23 +10,28 @@ menu_weight: 10.0
 
 ## Prerequisites
 
-[Java JDK, version 1.7](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and [Apache ANT](http://ant.apache.org/bindownload.cgi). For Ubuntu users:
+[Java JDK, version 1.7](http://www.oracle.com/technetwork/java/javase/downloads/index.html), [Apache ANT](http://ant.apache.org/bindownload.cgi), Git and wget. For Ubuntu users:
 
 ```
-apt-get install default-jdk-headless ant
+apt-get install default-jdk ant git wget
 ```
 
 For OSX, using Homebrew (install a JDK separately):
 
 ```
-brew install coreutils ant
+brew install coreutils ant git wget
 ```
 
 ## Getting Silver
 
-The **latest release** can be [downloaded here](/downloads/).
+To clone from GitHub,
+wherever you wish to checkout the repository, run:
 
-To clone from GitHub instead, [see below](#using-the-latest-development-version).
+```
+$ git clone https://github.com/melt-umn/silver.git
+$ cd silver
+silver$ ./update
+```
 
 ## Testing things out by building the tutorials
 
@@ -53,7 +58,7 @@ don't have a ~/bin, all you have to do is `mkdir ~/bin`, and the
 default shell scripts will notice it and add it to your `PATH` next
 time your shell is started. 
 
-At this point, Silver should be all set. You can test it with: (leaving off from above)
+At this point, Silver should be all set. You can test it with: (continuing from above)
 
 ```
 silver$ cd tutorials
@@ -63,45 +68,16 @@ silver/tutorials$ java -jar hello.jar
 Hello World!
 ```
 
-Note that this differs from previously by using the '`silver`' script
-in `~/bin` instead of the local `silver-compile` script, and it is
-only in the `tutorials` directory, not in `tutorials/hello`. 
+Note that this differs from the previous example session by using the '`silver`' script
+in `~/bin` instead of the local `silver-compile` script, and it is run
+from the `tutorials` directory instead of `tutorials/hello`.
 
 
-# Using the latest development version
-
-Instead of downloading a relase, Silver can be checked out directly from GitHub instead.
-
-## Additional prerequisites
-
-Git and wget. For Ubuntu users:
-
-```
-apt-get install default-jdk ant git wget
-```
-
-For OSX:
-
-```
-# Again, install Java separately.
-brew install coreutils ant git wget
-```
-
-## Checking out Silver
-
-Wherever you wish to checkout the repository, do this:
-
-```
-$ git clone https://github.com/melt-umn/silver.git
-$ cd silver
-silver$ ./update
-```
-
-And then proceed with the instructions above (e.g. testing with tutorials, installing `silver` to `~/bin`, etc.)
+# Updating to the latest development version
 
 ## Updating jars
 
-To update the a version cloned from GitHub, run:
+To update the version cloned from GitHub, run:
 
 ```
 silver$ ./update

--- a/silver/install-guide/index.md
+++ b/silver/install-guide/index.md
@@ -19,7 +19,7 @@ apt-get install default-jdk ant git wget
 For OSX, using Homebrew (install a JDK separately):
 
 ```
-brew install coreutils ant git wget
+brew install coreutils ant wget
 ```
 
 ## Getting Silver
@@ -32,6 +32,11 @@ $ git clone https://github.com/melt-umn/silver.git
 $ cd silver
 silver$ ./update
 ```
+
+This will pull the latest changes, and update your working copy. It
+will also download the latest jars (which may be necessary! Silver is
+written in Silver, so there can be bootstrapping issues) and clear out
+any generated files, which may now be stale with the new version.
 
 Alternatively, the latest stable release can be found on the [Downloads](/downloads/) page.
 
@@ -74,21 +79,6 @@ Note that this differs from the previous example session by using the '`silver`'
 in `~/bin` instead of the local `silver-compile` script, and it is run
 from the `tutorials` directory instead of `tutorials/hello`.
 
-
-# Updating to the latest development version
-
-## Updating jars
-
-To update the version cloned from GitHub, run:
-
-```
-silver$ ./update
-```
-
-This will pull the latest changes, and update your working copy. It
-will also download the latest jars (which may be necessary! Silver is
-written in Silver, so there can be bootstrapping issues) and clear out
-any generated files, which may now be stale with the new version.
 
 ## Building Silver
 

--- a/silver/install-guide/index.md
+++ b/silver/install-guide/index.md
@@ -33,6 +33,8 @@ $ cd silver
 silver$ ./update
 ```
 
+Alternatively, the latest stable release can be found on the [Downloads](/downloads/) page.
+
 ## Testing things out by building the tutorials
 
 Here is an example session, running the hello world tutorial grammar:


### PR DESCRIPTION
This moves the instructions to install Silver by cloning the github repo to the top of the installation guide, above the link to the Downloads page. This better matches what we tell most new Silver users to do.