### PR TITLE
Changing pattern matching page to explain new semantics

### DIFF
--- a/content/silver/ref/expr/pattern-matching.md
+++ b/content/silver/ref/expr/pattern-matching.md
@@ -67,7 +67,8 @@ Here the first pattern only matches when the value of the expression `lookupBy(.
 ## Matching Through Forwarding
 
 Because Silver is an extensible language and we allow matching on the productions of a nonterminal type, we want to be able to handle new productions with old pattern matches.
-To do this, if we do not find a match initially, we take the forward of the term we are matching on and try again.
+To do this, when we try to match a pattern, we forward if we do not initially have a match.
+This gives us the semantics of matching the first pattern which the value can match.
 
 For example, suppose we have the following production:
 ```
@@ -75,24 +76,53 @@ abstract production d
 top::Nonterminal ::= x::Nonterminal
 { forwards to a(x); }
 ```
-The result of the following pattern matching will be `4` because we have an exact match in the form of the pattern `d(_)`:
+The result of the following pattern matching will be `0` because we have an exact match in the first clasue in the form of the pattern `d(_)`:
 ```
 case d(c()) of
-| a(_) -> 1
-| b(_, _) -> 2
-| c() -> 3
-| d(_) -> 4
-end
-```
-However, if we do not have the `d(_)` pattern, we do not have an exact match.
-When we do not get a match for `d(c())`, we forward to `a(c())` and try again, matching the first pattern and giving a result of `1`:
-```
-case d(c()) of
+| d(_) -> 0
 | a(_) -> 1
 | b(_, _) -> 2
 | c() -> 3
 end
 ```
+Suppose we remove the `d(_)` pattern.
+We try to match `d(c())` against the `a(_)` pattern, but it does not match.
+We then forward to `a(c())` and try matching this pattern again, which succeeds, giving a result of `1`:
+```
+case d(c()) of
+| a(_) -> 1
+| b(_, _) -> 2
+| c() -> 3
+end
+```
+
+If we rearrange the rules in this last `case` expression, we get the same result.
+Matching `d(c())` against `b(_, _)` fails, so we forward and try again.
+Matching `a(c())` against `b(_, _)` also fails.
+Since we have no more forwards to try matching, we move on to the next pattern and try matching `d(c())` against it.
+When this fails, we forward again and find a match.
+```
+case d(c()) of
+| b(_, _) -> 2
+| a(_) -> 1
+| c() -> 3
+end
+```
+Suppose we rearrange the order of patterns from the case expression above with the `d(_)` pattern, placing it at the end of the match instead of the beginning.
+We will *not* get the same result in this case, since we take the first pattern which matches.
+We try to match `d(c())` against `a(_)`, which succeeds after forwarding, and the result is `1` rather than `0` as before.
+```
+case d(c()) of
+| a(_) -> 1
+| b(_, _) -> 2
+| c() -> 3
+| d(_) -> 0
+end
+```
+The relative order of patterns for forwarding and non-forwarding productions is relevant for which pattern matches.
+In this example, the `d(_)` pattern will never be reached because any trees built by the `d` production will match the `a(_)` pattern.
+To match a forwarding production, place it at the beginning of the clauses.
+It is not an error to place it later, but it is unlikely the resulting semantics are the intended ones.
 
 ## Completeness Analysis
 

--- a/content/silver/ref/expr/pattern-matching.md
+++ b/content/silver/ref/expr/pattern-matching.md
@@ -76,7 +76,7 @@ abstract production d
 top::Nonterminal ::= x::Nonterminal
 { forwards to a(x); }
 ```
-The result of the following pattern matching will be `0` because we have an exact match in the first clasue in the form of the pattern `d(_)`:
+The result of the following pattern matching will be `0` because we have an exact match in the first clause in the form of the pattern `d(_)`:
 ```
 case d(c()) of
 | d(_) -> 0


### PR DESCRIPTION
This changes the explanation of matching through forwarding to explain the new semantics of matching the first pattern which can match rather than searching for a matching pattern before forwarding and going back.